### PR TITLE
[사용자 검색 화면] 배열 정렬 로직을 네트워크 로직과 분리

### DIFF
--- a/AidenSeed.xcodeproj/project.pbxproj
+++ b/AidenSeed.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		560FC567EE3241602FFB37B4 /* Pods_AidenSeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3948B6267C93C277B3CEFB1F /* Pods_AidenSeed.framework */; };
+		BB4A88D228DEBC16002362D5 /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4A88D128DEBC16002362D5 /* Array+Extensions.swift */; };
 		DF03365C28B7381E004EAA23 /* ResultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF03365B28B7381E004EAA23 /* ResultCell.swift */; };
 		DF16128B28D2FA4400A90E46 /* RealmManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF16128A28D2FA4400A90E46 /* RealmManager.swift */; };
 		DF60BECD28B5DCF100158998 /* flying-rocket-in-the-sky.json in Resources */ = {isa = PBXBuildFile; fileRef = DF60BECC28B5DCF100158998 /* flying-rocket-in-the-sky.json */; };
@@ -46,6 +47,7 @@
 /* Begin PBXFileReference section */
 		3948B6267C93C277B3CEFB1F /* Pods_AidenSeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AidenSeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8E8B2E0992B48CDAD1BFAF40 /* Pods-AidenSeed.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AidenSeed.release.xcconfig"; path = "Target Support Files/Pods-AidenSeed/Pods-AidenSeed.release.xcconfig"; sourceTree = "<group>"; };
+		BB4A88D128DEBC16002362D5 /* Array+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
 		DDF9DBABA6BC565B929EDF41 /* Pods-AidenSeed.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AidenSeed.debug.xcconfig"; path = "Target Support Files/Pods-AidenSeed/Pods-AidenSeed.debug.xcconfig"; sourceTree = "<group>"; };
 		DF03365B28B7381E004EAA23 /* ResultCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultCell.swift; sourceTree = "<group>"; };
 		DF16128A28D2FA4400A90E46 /* RealmManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmManager.swift; sourceTree = "<group>"; };
@@ -160,6 +162,7 @@
 			children = (
 				DF9650C628BC70B900EF7992 /* String+Extensions.swift */,
 				DFA9E81928C04716003912E7 /* Date+Extensions.swift */,
+				BB4A88D128DEBC16002362D5 /* Array+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -350,6 +353,7 @@
 				DF9650C728BC70B900EF7992 /* String+Extensions.swift in Sources */,
 				DF60BEDF28B6094C00158998 /* SearchHistoryViewController.swift in Sources */,
 				DFB77C8728C17E44004826F5 /* UserInfoViewReactor.swift in Sources */,
+				BB4A88D228DEBC16002362D5 /* Array+Extensions.swift in Sources */,
 				DF60BEDD28B6094200158998 /* SearchUserViewController.swift in Sources */,
 				DFAD211C28C6C88000F06001 /* SearchHistoryViewReactor.swift in Sources */,
 				DF60BEDB28B5FEDA00158998 /* HomeViewReactor.swift in Sources */,

--- a/AidenSeed/API/GitHubProvider.swift
+++ b/AidenSeed/API/GitHubProvider.swift
@@ -76,7 +76,6 @@ extension GitHubProvider: TargetType {
     
 }
 
-//extension GitHubProvider {
 class GitHubAPI {
     
     /// 새로운 UserInfo 배열을 반환
@@ -90,13 +89,8 @@ class GitHubAPI {
                     guard let response = try? result.map(SearchUsersResponse.self) else { return }
                     guard let items = response.items else { return }
                     
-                    var sortedItems = items
-                    sortedItems.sort { (a, b) in
-                        return a.login ?? "" < b.login ?? ""
-                    }
-                    
                     // Observable<Mutation> 리턴 대신 observer에 방출
-                    observer.onNext(sortedItems)
+                    observer.onNext(items)
                     
                 case let .failure(result):
                     print("Error occurred!:\n\(result)")

--- a/AidenSeed/Extensions/Array+Extensions.swift
+++ b/AidenSeed/Extensions/Array+Extensions.swift
@@ -1,0 +1,15 @@
+//
+//  Array+Extensions.swift
+//  AidenSeed
+//
+//  Created by 여나경 on 2022/09/24.
+//
+
+extension Array where Element: UserInfo {
+    /// login(닉네임) 따라 정렬
+    func sortedItems() -> [UserInfo] {
+        return self.sorted { (a, b) in
+            return a.login ?? "" < b.login ?? ""
+        }
+    }
+}

--- a/AidenSeed/ViewControllers/SearchUserViewReactor.swift
+++ b/AidenSeed/ViewControllers/SearchUserViewReactor.swift
@@ -32,8 +32,11 @@ class SearchUserViewReactor: Reactor {
         switch action {
         case .resetAndSearch(let userName, let createdBefore):
             return Observable.concat([
-                gitHubAPI.loadMoreUsers(userName, createdBefore: createdBefore, nextPage: 1).map {
-                    .resetAndSearchUserNames($0)
+                gitHubAPI.loadMoreUsers(userName, createdBefore: createdBefore, nextPage: 1)
+                // TODO: 원하는 것 >> Array의 extension인 sortedItems를 사용해서 아래와 비슷하게'.sortedItems'로 사용
+//                    .sortedItems()
+                    .map {
+                        .resetAndSearchUserNames($0.sortedItems())
                 }
             ])
         case .loadMore(let userName, let createdBefore, let nextPage):
@@ -59,3 +62,4 @@ class SearchUserViewReactor: Reactor {
     
     var initialState: State = State()
 }
+


### PR DESCRIPTION
[사용자 검색 화면]
* 배열 정렬 로직을 네트워크 로직과 분리
* Array의 extension, element는 `UserInfo`에 대해서만 적용되는 `sortedItems()`