### PR TITLE
Test 작성: KeywordType의 static 함수들

### DIFF
--- a/AidenSeed.xcodeproj/project.pbxproj
+++ b/AidenSeed.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		560FC567EE3241602FFB37B4 /* Pods_AidenSeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3948B6267C93C277B3CEFB1F /* Pods_AidenSeed.framework */; };
+		BB2B2C7328F415C700F516E9 /* AidenSeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB2B2C7228F415C700F516E9 /* AidenSeedTests.swift */; };
 		BB4A88D228DEBC16002362D5 /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4A88D128DEBC16002362D5 /* Array+Extensions.swift */; };
 		BBBE9A7228E18A79001C8048 /* UITableView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBE9A7128E18A79001C8048 /* UITableView+Extensions.swift */; };
 		DF03365C28B7381E004EAA23 /* ResultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF03365B28B7381E004EAA23 /* ResultCell.swift */; };
@@ -45,9 +46,21 @@
 		DFD9729F28BC5580003DDBD4 /* GitHubProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD9729E28BC5580003DDBD4 /* GitHubProvider.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		BB2B2C7428F415C700F516E9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DFA2A0F828B5AF5600588C97 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DFA2A0FF28B5AF5600588C97;
+			remoteInfo = AidenSeed;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		3948B6267C93C277B3CEFB1F /* Pods_AidenSeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AidenSeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8E8B2E0992B48CDAD1BFAF40 /* Pods-AidenSeed.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AidenSeed.release.xcconfig"; path = "Target Support Files/Pods-AidenSeed/Pods-AidenSeed.release.xcconfig"; sourceTree = "<group>"; };
+		BB2B2C7028F415C700F516E9 /* AidenSeedTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AidenSeedTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		BB2B2C7228F415C700F516E9 /* AidenSeedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AidenSeedTests.swift; sourceTree = "<group>"; };
 		BB4A88D128DEBC16002362D5 /* Array+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
 		BBBE9A7128E18A79001C8048 /* UITableView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Extensions.swift"; sourceTree = "<group>"; };
 		DDF9DBABA6BC565B929EDF41 /* Pods-AidenSeed.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AidenSeed.debug.xcconfig"; path = "Target Support Files/Pods-AidenSeed/Pods-AidenSeed.debug.xcconfig"; sourceTree = "<group>"; };
@@ -86,6 +99,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		BB2B2C6D28F415C700F516E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DFA2A0FD28B5AF5600588C97 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -107,6 +127,14 @@
 				8E8B2E0992B48CDAD1BFAF40 /* Pods-AidenSeed.release.xcconfig */,
 			);
 			path = Pods;
+			sourceTree = "<group>";
+		};
+		BB2B2C7128F415C700F516E9 /* AidenSeedTests */ = {
+			isa = PBXGroup;
+			children = (
+				BB2B2C7228F415C700F516E9 /* AidenSeedTests.swift */,
+			);
+			path = AidenSeedTests;
 			sourceTree = "<group>";
 		};
 		D5BBDE2DE3E81EBCEA296032 /* Frameworks */ = {
@@ -182,6 +210,7 @@
 			isa = PBXGroup;
 			children = (
 				DFA2A10228B5AF5600588C97 /* AidenSeed */,
+				BB2B2C7128F415C700F516E9 /* AidenSeedTests */,
 				DFA2A10128B5AF5600588C97 /* Products */,
 				621C645D07F66C453A234264 /* Pods */,
 				D5BBDE2DE3E81EBCEA296032 /* Frameworks */,
@@ -192,6 +221,7 @@
 			isa = PBXGroup;
 			children = (
 				DFA2A10028B5AF5600588C97 /* AidenSeed.app */,
+				BB2B2C7028F415C700F516E9 /* AidenSeedTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -226,6 +256,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		BB2B2C6F28F415C700F516E9 /* AidenSeedTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BB2B2C7828F415C700F516E9 /* Build configuration list for PBXNativeTarget "AidenSeedTests" */;
+			buildPhases = (
+				BB2B2C6C28F415C700F516E9 /* Sources */,
+				BB2B2C6D28F415C700F516E9 /* Frameworks */,
+				BB2B2C6E28F415C700F516E9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BB2B2C7528F415C700F516E9 /* PBXTargetDependency */,
+			);
+			name = AidenSeedTests;
+			productName = AidenSeedTests;
+			productReference = BB2B2C7028F415C700F516E9 /* AidenSeedTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		DFA2A0FF28B5AF5600588C97 /* AidenSeed */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = DFA2A11428B5AF5800588C97 /* Build configuration list for PBXNativeTarget "AidenSeed" */;
@@ -260,6 +308,10 @@
 				LastSwiftUpdateCheck = 1340;
 				LastUpgradeCheck = 1340;
 				TargetAttributes = {
+					BB2B2C6F28F415C700F516E9 = {
+						CreatedOnToolsVersion = 13.4.1;
+						TestTargetID = DFA2A0FF28B5AF5600588C97;
+					};
 					DFA2A0FF28B5AF5600588C97 = {
 						CreatedOnToolsVersion = 13.4;
 					};
@@ -283,11 +335,19 @@
 			projectRoot = "";
 			targets = (
 				DFA2A0FF28B5AF5600588C97 /* AidenSeed */,
+				BB2B2C6F28F415C700F516E9 /* AidenSeedTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		BB2B2C6E28F415C700F516E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DFA2A0FE28B5AF5600588C97 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -349,6 +409,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		BB2B2C6C28F415C700F516E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BB2B2C7328F415C700F516E9 /* AidenSeedTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DFA2A0FC28B5AF5600588C97 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -381,6 +449,14 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		BB2B2C7528F415C700F516E9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DFA2A0FF28B5AF5600588C97 /* AidenSeed */;
+			targetProxy = BB2B2C7428F415C700F516E9 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin PBXVariantGroup section */
 		DFA2A10E28B5AF5800588C97 /* LaunchScreen.storyboard */ = {
 			isa = PBXVariantGroup;
@@ -393,6 +469,42 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		BB2B2C7628F415C700F516E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 8DJU9A2RCC;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.nagyeong.AidenSeedTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AidenSeed.app/AidenSeed";
+			};
+			name = Debug;
+		};
+		BB2B2C7728F415C700F516E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 8DJU9A2RCC;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.nagyeong.AidenSeedTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AidenSeed.app/AidenSeed";
+			};
+			name = Release;
+		};
 		DFA2A11228B5AF5800588C97 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -568,6 +680,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		BB2B2C7828F415C700F516E9 /* Build configuration list for PBXNativeTarget "AidenSeedTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BB2B2C7628F415C700F516E9 /* Debug */,
+				BB2B2C7728F415C700F516E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		DFA2A0FB28B5AF5600588C97 /* Build configuration list for PBXProject "AidenSeed" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/AidenSeed.xcodeproj/xcshareddata/xcschemes/AidenSeed.xcscheme
+++ b/AidenSeed.xcodeproj/xcshareddata/xcschemes/AidenSeed.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BB2B2C6F28F415C700F516E9"
+               BuildableName = "AidenSeedTests.xctest"
+               BlueprintName = "AidenSeedTests"
+               ReferencedContainer = "container:AidenSeed.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/AidenSeedTests/AidenSeedTests.swift
+++ b/AidenSeedTests/AidenSeedTests.swift
@@ -83,7 +83,7 @@ class AidenSeedTests: XCTestCase {
         XCTAssertEqual(guess9, "9", "First digit computed from guess9 is wrong")
     }
 
-    func testKeywordTypeIsComputedWhenUserIDFirstDigitIsLessThanOrEqualWithFive() {
+    func testKeywordTypeIsComputedWhenUserIDFirstDigitIsLessThanOrEqualToFive() {
       // given
         let userID1 = 1
         let userID2 = 2

--- a/AidenSeedTests/AidenSeedTests.swift
+++ b/AidenSeedTests/AidenSeedTests.swift
@@ -1,0 +1,126 @@
+//
+//  AidenSeedTests.swift
+//  AidenSeedTests
+//
+//  Created by 여나경 on 2022/10/10.
+
+// 참고
+// - https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods
+// - https://developer.apple.com/documentation/xctest/xctestcase/set_up_and_tear_down_state_in_your_tests
+// - https://www.raywenderlich.com/21020457-ios-unit-testing-and-ui-testing-tutorial
+
+import XCTest
+
+@testable import AidenSeed
+
+class AidenSeedTests: XCTestCase {
+    var sut: SearchUserViewController!
+    
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+        try super.setUpWithError()
+        sut = SearchUserViewController()
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        sut = nil
+        try super.tearDownWithError()
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+        
+//      let guess = sut.getFilledResultCell(userInfo: userInfo)
+        // TODO: Q. 테스트를 위해 private func으로 설정하면 안될지?
+        
+        // when
+//      sut.check(guess: guess1)
+        
+        // then
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+    
+    func testFirstDigitIsComputed() {
+        let userID1 = 1
+        let userID2 = 2
+        let userID3 = 3
+        let userID4 = 4
+        let userID5 = 5
+        let userID6 = 6
+        let userID7 = 7
+        let userID8 = 8
+        let userID9 = 9
+        
+        let guess1 = KeywordType.getFirstDigit(userID1)
+        let guess2 = KeywordType.getFirstDigit(userID2)
+        let guess3 = KeywordType.getFirstDigit(userID3)
+        let guess4 = KeywordType.getFirstDigit(userID4)
+        let guess5 = KeywordType.getFirstDigit(userID5)
+        let guess6 = KeywordType.getFirstDigit(userID6)
+        let guess7 = KeywordType.getFirstDigit(userID7)
+        let guess8 = KeywordType.getFirstDigit(userID8)
+        let guess9 = KeywordType.getFirstDigit(userID9)
+        
+        XCTAssertEqual(guess1, "1", "First digit computed from guess1 is wrong")
+        XCTAssertEqual(guess2, "2", "First digit computed from guess2 is wrong")
+        XCTAssertEqual(guess3, "3", "First digit computed from guess3 is wrong")
+        XCTAssertEqual(guess4, "4", "First digit computed from guess4 is wrong")
+        XCTAssertEqual(guess5, "5", "First digit computed from guess5 is wrong")
+        XCTAssertEqual(guess6, "6", "First digit computed from guess6 is wrong")
+        XCTAssertEqual(guess7, "7", "First digit computed from guess7 is wrong")
+        XCTAssertEqual(guess8, "8", "First digit computed from guess8 is wrong")
+        XCTAssertEqual(guess9, "9", "First digit computed from guess9 is wrong")
+    }
+
+    func testKeywordTypeIsComputedWhenUserIDFirstDigitIsLessThanOrEqualWithFive() {
+      // given
+        let userID1 = 1
+        let userID2 = 2
+        let userID3 = 3
+        let userID4 = 4
+        let userID5 = 5
+        
+        let guess1 = KeywordType.getKeywordType(userID: userID1)
+        let guess2 = KeywordType.getKeywordType(userID: userID2)
+        let guess3 = KeywordType.getKeywordType(userID: userID3)
+        let guess4 = KeywordType.getKeywordType(userID: userID4)
+        let guess5 = KeywordType.getKeywordType(userID: userID5)
+        
+      // then
+        XCTAssertEqual(guess1, .imageRight, "KeywordType computed from guess1 is wrong")
+        XCTAssertEqual(guess2, .imageRight, "KeywordType computed from guess2 is wrong")
+        XCTAssertEqual(guess3, .imageRight, "KeywordType computed from guess3 is wrong")
+        XCTAssertEqual(guess4, .imageRight, "KeywordType computed from guess4 is wrong")
+        XCTAssertEqual(guess5, .imageRight, "KeywordType computed from guess5 is wrong")
+    }
+    
+    func testKeywordTypeIsComputedWhenUserIDFirstDigitIsGreaterThanFive() {
+      // given
+        let userID6 = 6
+        let userID7 = 7
+        let userID8 = 8
+        let userID9 = 9
+        
+        let guess6 = KeywordType.getKeywordType(userID: userID6)
+        let guess7 = KeywordType.getKeywordType(userID: userID7)
+        let guess8 = KeywordType.getKeywordType(userID: userID8)
+        let guess9 = KeywordType.getKeywordType(userID: userID9)
+
+      // then
+        XCTAssertEqual(guess6, .imageLeft, "KeywordType computed from guess6 is wrong")
+        XCTAssertEqual(guess7, .imageLeft, "KeywordType computed from guess7 is wrong")
+        XCTAssertEqual(guess8, .imageLeft, "KeywordType computed from guess8 is wrong")
+        XCTAssertEqual(guess9, .imageLeft, "KeywordType computed from guess9 is wrong")
+    }
+}


### PR DESCRIPTION
* Test 작성
  * getFirstDigit(), getKeywordType()
  * `XCTAssertEqual()` 사용
  * 실행순서: `setUpWithError()` --> 테스트함수 --> `tearDownWithError()`
  * 의문: `SearchUserViewController` > `getFilledResultCell()` 같은 경우, 테스트를 위해 private func으로 설정하면 안되는건지?
